### PR TITLE
fix(graph): stop reporting unparseable governing comments as absent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ When orchestrating multiple SDD plugin skills in a single session (e.g., running
 
 Run `make check` (`make test` + `make lint` + `make scan`) before pushing.
 
-- `make test` runs the docs-site build-script unit tests (`node --test`) and then a full docs-site build.
+- `make test` runs the docs-site build-script unit tests (`node --test`), the `/sdd:graph` helper's unit tests (`python3 -m unittest` over `skills/graph/lib/`), and then a full docs-site build.
 - `make lint` runs `scripts/check-structure.sh` — plugin manifest, SKILL.md frontmatter, `skills/_index.json` consistency, eval definition shape, and a guard against bare `JSX.Element` annotations in `templates/` — plus a docs-site typecheck.
 - `make scan` runs `scripts/gitleaks-scan.sh` — gitleaks over git history and the working tree. Needs `gitleaks` installed (`brew install gitleaks`); it fails rather than skipping when the tool is missing.
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ help: ## Show this help
 check: test lint scan ## Run tests, linters, and the secret scan
 
 .PHONY: test
-test: test-unit build ## Run the build-script unit tests, then build the docs site
+test: test-unit test-graph build ## Run the build-script and graph-helper unit tests, then build the docs site
 
 .PHONY: lint
 lint: lint-structure lint-types ## Validate plugin structure and docs-site types
@@ -52,6 +52,13 @@ test-unit: $(NODE_MODULES) ## Run the docs-site build-script unit tests
 			echo "no *.test.js files found under $(DOCS_SITE)/scripts" >&2; exit 1; \
 		fi; \
 		node --test $$files
+
+# The /sdd:graph helper is the one piece of the plugin that is code rather
+# than markdown, and its parsing rules (governing comments, frontmatter) have
+# already regressed silently once (#216). Stdlib unittest, no dependencies.
+.PHONY: test-graph
+test-graph: ## Run the /sdd:graph helper unit tests
+	python3 -m unittest discover -s skills/graph/lib -p 'test_*.py'
 
 # --- Lint components -------------------------------------------------------
 

--- a/docs/openspec/specs/artifact-graph/spec.md
+++ b/docs/openspec/specs/artifact-graph/spec.md
@@ -173,7 +173,7 @@ The `/sdd:graph` skill SHALL support two diagnostic query verbs that operate ove
 
 | Verb | Behavior |
 |------|----------|
-| `orphans` | Returns three categories: (a) source files with no governing comment block, (b) specs with no implementing source files, (c) ADRs with no implementing spec |
+| `orphans` | Returns four categories: (a) source files with no governing comment block, (a') source files that contain a `Governing:` marker from which no artifact ID could be parsed, reported with the reason, (b) specs with no implementing source files, (c) ADRs with no implementing spec |
 | `cycles` | Returns all cycles detected during validation. If validation passed, returns an empty result. |
 
 Diagnostic verbs MUST tolerate large outputs by supporting an optional scope filter (e.g., `--scope src/auth/` to limit `orphans` detection to a subtree).
@@ -182,6 +182,17 @@ Diagnostic verbs MUST tolerate large outputs by supporting an optional scope fil
 
 - **WHEN** the user runs `/sdd:graph orphans` and 5 source files lack governing comment blocks
 - **THEN** the output SHALL list those files under "Source files without governing artifacts"
+
+#### Scenario: Unrecognized governing comment
+
+- **WHEN** a source file contains a `Governing:` marker that names no `ADR-XXXX` / `SPEC-XXXX` artifact (for example `// Governing: #24`), or uses a comment opener the parser does not accept
+- **THEN** the `orphans` output SHALL list the file under "Source files with unrecognized governing comments" with the reason, and SHALL NOT list it under "Source files without governing artifacts"
+- **AND** `validate` SHALL emit a `governing-unrecognized` warning for the file
+
+#### Scenario: Multiple governing lines in one file
+
+- **WHEN** a source file's first `Governing:` line names only an issue and a later `Governing:` line names ADR-0009 and SPEC-0006
+- **THEN** the graph SHALL contain edges from the file to both ADR-0009 and SPEC-0006, and neither artifact SHALL be reported as orphaned on account of that file
 
 #### Scenario: Orphan spec
 

--- a/references/shared-patterns.md
+++ b/references/shared-patterns.md
@@ -443,6 +443,8 @@ All skills that generate or modify code MUST use file-level governing comment bl
 
 For markdown files: `<!-- Governing: ... -->`
 
+`/sdd:graph` reads the first 4096 bytes of each file, accepts `//`, `#`, `<!--`, `*` (JSDoc / block-comment continuation) and `/*` as openers, and unions the artifact IDs from every `Governing:` / `Implements:` line it finds. A `Governing:` / `Implements:` line that names no `ADR-XXXX` / `SPEC-XXXX` (an issue reference, say) is reported by `validate` and `orphans` as *unrecognized* rather than treated as absent.
+
 ### Rules
 - MUST use file-level blocks at the top of each file (not per-line annotations)
 - Inline governing comments SHOULD only be used when the connection is non-obvious from the file-level block

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -103,13 +103,16 @@ Single contiguous bidirectional diagram: ancestors above (rendered as top-down c
 
 ### `orphans`
 
-Surfaces three categories of orphan as flat markdown tables (default for flat results per SPEC-0018):
+Surfaces four categories of orphan as flat markdown tables (default for flat results per SPEC-0018):
 
-1. **Source files without governing artifacts** — non-markdown source files in the project tree that contain no `Governing:` comment block. Discovered by a dedicated walk so these files do not become graph nodes (they remain invisible to traversal queries) but DO surface here. The walk uses the same exclusions as the graph builder (`.git`, `node_modules`, `vendor`, build/cache dirs, `docs/`, `skills/`, `references/`, etc.). Markdown files are skipped — they participate via frontmatter (ADRs, specs) or are out of scope for v1 (READMEs, ad-hoc docs).
-2. **Specs with no implementing code** — specs that no source file's governing comment references.
-3. **ADRs with no implementing spec** — ADRs that no spec declares `implements:` against.
+1. **Source files without governing artifacts** — non-markdown source files in the project tree that contain no `Governing:` comment at all. Discovered by a dedicated walk so these files do not become graph nodes (they remain invisible to traversal queries) but DO surface here. The walk uses the same exclusions as the graph builder (`.git`, `node_modules`, `vendor`, build/cache dirs, `docs/`, `skills/`, `references/`, etc.). Markdown files are skipped — they participate via frontmatter (ADRs, specs) or are out of scope for v1 (READMEs, ad-hoc docs).
+2. **Source files with unrecognized governing comments** — files that DO contain a `Governing:` marker but from which the parser could read no `ADR-XXXX` / `SPEC-XXXX` ID: an issue-only reference (`// Governing: #24`), or a comment opener the parser does not accept. Each row carries the reason. These are listed apart from category 1 because the fix is the opposite — reformat the comment the file already has, do not add another. The same files also surface as `governing-unrecognized` warnings in `validate`.
+3. **Specs with no implementing code** — specs that no source file's governing comment references.
+4. **ADRs with no implementing spec** — ADRs that no spec declares `implements:` against.
 
-Optional `--scope <subtree>` restricts category 1 to source files under the given path. Categories 2 and 3 always cover the full graph.
+Optional `--scope <subtree>` restricts categories 1 and 2 to source files under the given path. Categories 3 and 4 always cover the full graph.
+
+**How governing comments are read.** The helper scans the first 4096 bytes of each file for every line matching `<opener> Governing: ...` or `<opener> Implements: ...` — openers are `//`, `#`, `<!--`, `*` (JSDoc / block-comment continuation), and `/*` — and unions the artifact IDs across all of them. The canonical two-line block (`Governing:` + `Implements:`) and a repo that keeps an issue-style line above the artifact-style one are therefore both credited correctly; the first `Governing:` line no longer decides the file's fate on its own.
 
 **Operator-facing framing.** A spec is flagged whenever no `Governing:` comment in source code references it; comment-less code is invisible by design (per SPEC-0018 § "Files without governing comments"). For repos that haven't yet attached governing comments to source code, expect every spec and ADR to be flagged. The output includes a one-line preamble explaining this so first-time readers know the verb is working as intended, not reporting a real catastrophe.
 
@@ -216,6 +219,7 @@ Distinguishable from success responses by the presence of a top-level `error` fi
   "query": {"verb": "orphans"},
   "results": {
     "code_files_without_governing": [...],
+    "code_files_with_unrecognized_governing": [{"file": "...", "reason": "..."}, ...],
     "specs_without_implementing_code": [...],
     "adrs_without_implementing_spec": [...]
   }

--- a/skills/graph/lib/graph.py
+++ b/skills/graph/lib/graph.py
@@ -303,19 +303,43 @@ def _read_text(path: Path) -> str:
         return ""
 
 
-# Governing comment block per ADR-0020 / SPEC-0016 REQ "Governing Comment Format".
-# File-level only — first comment line that starts with `Governing:`.
+# Governing Comment Parsing
+#
+# Governing comment lines per ADR-0020 / SPEC-0016 REQ "Governing Comment
+# Format". Every `Governing:` and `Implements:` line in the file head is
+# considered and the artifact IDs they name are unioned — the canonical block
+# is two lines (`Governing:` + `Implements:`), and a repo may carry an
+# issue-style line (`// Governing: #24`) above the artifact-style one. Taking
+# only the first `Governing:` match let the issue line suppress the real one
+# and never credited the `Implements:` line at all.
+#
+# A file that contains the `Governing:` marker but yields no ADR-XXXX /
+# SPEC-XXXX IDs is reported separately from a file with no marker at all
+# (see `_walk_code_files`): "no traceability" and "traceability the parser
+# cannot read" call for opposite responses from the operator.
+#
+# @joestump 09/03/2026 - Accept `*` as an opener (JSDoc / block-comment
+# continuation lines), scan all matches instead of the first, and classify
+# unrecognized governing comments instead of folding them into orphans (#216).
 _GOVERNING_RE = re.compile(
     r"""
     ^[ \t]*                       # optional leading indent
-    (?://|\#|<!--)                # comment opener: //, #, <!--
-    [ \t]*Governing:[ \t]*        # marker
+    (?://|\#|<!--|\*|/\*)         # comment opener: //, #, <!--, * (JSDoc), /*
+    [ \t]*(?:Governing|Implements):[ \t]*  # marker (both lines of the block)
     (.+?)                         # body of governing line (non-greedy)
-    [ \t]*(?:-->)?[ \t]*$         # optional --> closer for HTML comments
+    [ \t]*(?:-->|\*/)?[ \t]*$     # optional closer for HTML / block comments
     """,
     re.IGNORECASE | re.VERBOSE | re.MULTILINE,
 )
+# Loose marker probe: any `Governing:` token, regardless of opener. A hit here
+# with no `_GOVERNING_RE` match means the comment is in a shape the parser
+# does not accept (unknown opener, mid-line placement, ...).
+_GOVERNING_MARKER_RE = re.compile(r"\b(?:Governing|Implements):", re.IGNORECASE)
 _GOVERNING_ID_RE = re.compile(r"\b(ADR-\d{4}|SPEC-\d{4})\b")
+
+# Reasons attached to files whose governing comment could not be used.
+UNRECOGNIZED_NO_IDS = "governing comment names no ADR-XXXX / SPEC-XXXX artifact"
+UNRECOGNIZED_OPENER = "`Governing:` present but not in a recognized comment opener"
 
 _DEFAULT_CODE_EXCLUDES = frozenset(
     {".git", "node_modules", "vendor", ".venv", "venv", "__pycache__",
@@ -330,7 +354,7 @@ def discover_code_edges(root: Path, excludes: frozenset[str] = _DEFAULT_CODE_EXC
     whose first 4096 bytes contain a governing-comment block. Markdown files
     are skipped — they participate via frontmatter, not governing comments.
     """
-    edges, _ = _walk_code_files(root, excludes)
+    edges, _, _ = _walk_code_files(root, excludes)
     return edges
 
 
@@ -347,22 +371,44 @@ def discover_orphan_code(
     "Code files" excludes markdown (`.md`, `.markdown`) — markdown
     participates via frontmatter, not governing comments. It also
     excludes binary files (any file whose head doesn't decode as UTF-8).
+
+    Files that carry a `Governing:` marker the parser cannot use are NOT
+    in this list — see `discover_unrecognized_governing`.
     """
-    _, orphans = _walk_code_files(root, excludes)
+    _, orphans, _ = _walk_code_files(root, excludes)
     return orphans
+
+
+def discover_unrecognized_governing(
+    root: Path, excludes: frozenset[str] = _DEFAULT_CODE_EXCLUDES
+) -> list[tuple[Path, str]]:
+    """Walk `root` and return (path, reason) for code files whose head
+    contains a `Governing:` marker that yields no artifact IDs.
+
+    These are neither governed (no edge can be built) nor comment-less
+    (the author did attempt traceability). Reporting them as orphans told
+    the operator to add a comment the file already has.
+    """
+    _, _, unrecognized = _walk_code_files(root, excludes)
+    return unrecognized
 
 
 def _walk_code_files(
     root: Path, excludes: frozenset[str]
-) -> tuple[list[tuple[Path, list[str]]], list[Path]]:
-    """Single tree walk that returns both governed-edge files and orphan files.
+) -> tuple[list[tuple[Path, list[str]]], list[Path], list[tuple[Path, str]]]:
+    """Single tree walk that classifies every code file in `root`.
 
-    Returns (edges, orphans):
-      - edges: list of (path, ids) for files with governing comment blocks
-      - orphans: list of paths for files without governing comment blocks
+    Returns (edges, orphans, unrecognized):
+      - edges: list of (path, ids) for files whose governing comment lines
+        name at least one artifact. IDs are unioned across every matching
+        line in the head, not taken from the first line only.
+      - orphans: list of paths for files with no `Governing:` marker at all
+      - unrecognized: list of (path, reason) for files that contain the
+        marker but from which no artifact ID could be read
     """
     edges: list[tuple[Path, list[str]]] = []
     orphans: list[Path] = []
+    unrecognized: list[tuple[Path, str]] = []
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames[:] = sorted(
             d for d in dirnames if d not in excludes and not d.startswith(".")
@@ -383,20 +429,22 @@ def _walk_code_files(
             # Skip files that look binary (high non-printable ratio).
             if _looks_binary(head):
                 continue
-            m = _GOVERNING_RE.search(text)
-            if m:
-                ids = sorted(set(_GOVERNING_ID_RE.findall(m.group(1))))
-                if ids:
-                    edges.append((path, ids))
-                else:
-                    # Block exists but referenced no IDs — treat as comment-less
-                    # for orphan purposes.
-                    orphans.append(path)
+            matches = list(_GOVERNING_RE.finditer(text))
+            ids: set[str] = set()
+            for m in matches:
+                ids.update(_GOVERNING_ID_RE.findall(m.group(1)))
+            if ids:
+                edges.append((path, sorted(ids)))
+            elif matches:
+                unrecognized.append((path, UNRECOGNIZED_NO_IDS))
+            elif _GOVERNING_MARKER_RE.search(text):
+                unrecognized.append((path, UNRECOGNIZED_OPENER))
             else:
                 orphans.append(path)
     return (
         sorted(edges, key=lambda t: str(t[0])),
         sorted(orphans),
+        sorted(unrecognized, key=lambda t: str(t[0])),
     )
 
 
@@ -606,7 +654,8 @@ def build_graph(
     # authored in code (per ADR-0020). Downstream verbs that distinguish
     # provenance can read the source-node `kind` (code vs adr/spec) along
     # with the `derived` flag.
-    for path, ids in discover_code_edges(root):
+    code_edges, _, unrecognized_governing = _walk_code_files(root, _DEFAULT_CODE_EXCLUDES)
+    for path, ids in code_edges:
         rel = str(path.relative_to(root)) if path.is_relative_to(root) else str(path)
         full_node = prefix + rel
         if full_node not in g.nodes:
@@ -614,6 +663,23 @@ def build_graph(
         for target in ids:
             full_target = _maybe_prefix_target(target, prefix)
             g.edges.append(Edge(source=full_node, target=full_target, type="governed-by", derived=False))
+
+    # 3b. Governing comments the parser could not use. Same class as the
+    # authored-derived-field warning: the file is not wrong enough to block
+    # queries, but silently treating it as ungoverned hid the real problem
+    # behind a misleading `orphans` row (#216).
+    for path, reason in unrecognized_governing:
+        rel = str(path.relative_to(root)) if path.is_relative_to(root) else str(path)
+        g.add_diagnostic(
+            severity="warning",
+            code="governing-unrecognized",
+            message=(
+                f"{prefix}{rel}: {reason} — file is treated as ungoverned. "
+                "Expected `// Governing: ADR-XXXX (...), SPEC-XXXX REQ \"...\"` "
+                "at the top of the file (openers: //, #, <!--, *, /*)."
+            ),
+            source_id=prefix + rel,
+        )
 
     # 4. Validate.
     _validate(g)
@@ -1642,6 +1708,10 @@ def _orphans_json(graph: Graph, root: Path, scope: str | None) -> str:
         "query": {"verb": "orphans", "scope": scope} if scope else {"verb": "orphans"},
         "results": {
             "code_files_without_governing": _orphan_code(graph, root, scope),
+            "code_files_with_unrecognized_governing": [
+                {"file": rel, "reason": reason}
+                for rel, reason in _unrecognized_code(graph, root, scope)
+            ],
             "specs_without_implementing_code": _orphan_specs(graph),
             "adrs_without_implementing_spec": _orphan_adrs(graph),
         },
@@ -1700,11 +1770,15 @@ def _validate_json(graph: Graph) -> str:
 def cmd_orphans(graph: Graph, root: Path, scope: str | None = None) -> str:
     """Render orphan diagnostic per SPEC-0018 REQ "Diagnostic Query Verbs".
 
-    Three orphan categories:
+    Four orphan categories:
       a. Source files with no governing comment block — found via a fresh
          walk of `root` (using the same exclusions as the graph builder).
          These files are NOT graph nodes, per SPEC-0018: they remain
          invisible to traversal queries and surface only here.
+      a'. Source files whose governing comment the parser could not use
+         (marker present, no artifact IDs readable). Listed apart from (a)
+         because the fix is different: reformat the comment, do not add
+         one. Each row carries the reason.
       b. Specs with no implementing source files — specs that no code
          file's governing comment references.
       c. ADRs with no implementing spec — ADRs that no spec declares
@@ -1716,16 +1790,17 @@ def cmd_orphans(graph: Graph, root: Path, scope: str | None = None) -> str:
     comments to source code, expect every spec and ADR to be flagged.
 
     Output is a flat markdown table per SPEC-0018 (default for flat
-    results). Optional `scope` filter restricts category (a) to files
-    under the given subtree.
+    results). Optional `scope` filter restricts categories (a) and (a')
+    to files under the given subtree.
     """
     out: list[str] = ["# /sdd:graph orphans", ""]
 
     code_orphans = _orphan_code(graph, root, scope)
+    code_unrecognized = _unrecognized_code(graph, root, scope)
     spec_orphans = _orphan_specs(graph)
     adr_orphans = _orphan_adrs(graph)
 
-    if not (code_orphans or spec_orphans or adr_orphans):
+    if not (code_orphans or code_unrecognized or spec_orphans or adr_orphans):
         out.append("No orphans detected.")
         out.append("")
         return "\n".join(out)
@@ -1734,7 +1809,9 @@ def cmd_orphans(graph: Graph, root: Path, scope: str | None = None) -> str:
         "Orphans surface artifacts that have no traceability link to code: a spec is "
         "flagged whenever no `Governing:` comment in source code references it, "
         "and an ADR is flagged whenever no spec declares `implements:` against it. "
-        "Source files without governing comments are listed separately."
+        "Source files without governing comments are listed separately, and source "
+        "files whose `Governing:` comment could not be parsed are listed apart from "
+        "those — they need the comment reformatted, not added."
     )
     out.append("")
 
@@ -1745,6 +1822,15 @@ def cmd_orphans(graph: Graph, root: Path, scope: str | None = None) -> str:
         out.append("|------|")
         for path in code_orphans:
             out.append(f"| `{_md_escape(path)}` |")
+        out.append("")
+
+    if code_unrecognized:
+        out.append("## Source files with unrecognized governing comments")
+        out.append("")
+        out.append("| File | Reason |")
+        out.append("|------|--------|")
+        for path, reason in code_unrecognized:
+            out.append(f"| `{_md_escape(path)}` | {_md_escape(reason)} |")
         out.append("")
 
     if spec_orphans:
@@ -1794,15 +1880,39 @@ def _orphan_code(graph: Graph, root: Path, scope: str | None) -> list[str]:
     `scope` filters results to a subtree. Empty / `.` / `./` / leading
     `./` are all normalized to "include everything."
     """
-    paths = discover_orphan_code(root)
-    scope_clean = (scope or "").lstrip("./").rstrip("/")
     rel_paths: list[str] = []
-    for p in paths:
-        rel = str(p.relative_to(root)) if p.is_relative_to(root) else str(p)
-        if scope_clean and not (rel == scope_clean or rel.startswith(scope_clean + "/")):
-            continue
-        rel_paths.append(rel)
+    for p in discover_orphan_code(root):
+        rel = _rel_path(root, p)
+        if _in_scope(rel, scope):
+            rel_paths.append(rel)
     return rel_paths
+
+
+def _unrecognized_code(graph: Graph, root: Path, scope: str | None) -> list[tuple[str, str]]:
+    """Code files with a `Governing:` marker the parser could not use, as
+    (relative path, reason) pairs. Same walk, exclusions, and scope
+    semantics as `_orphan_code`.
+    """
+    out: list[tuple[str, str]] = []
+    for p, reason in discover_unrecognized_governing(root):
+        rel = _rel_path(root, p)
+        if _in_scope(rel, scope):
+            out.append((rel, reason))
+    return out
+
+
+def _rel_path(root: Path, p: Path) -> str:
+    return str(p.relative_to(root)) if p.is_relative_to(root) else str(p)
+
+
+def _in_scope(rel: str, scope: str | None) -> bool:
+    """True when `rel` is under `scope`. Empty / `.` / `./` / leading `./`
+    are all normalized to "include everything."
+    """
+    scope_clean = (scope or "").lstrip("./").rstrip("/")
+    if not scope_clean:
+        return True
+    return rel == scope_clean or rel.startswith(scope_clean + "/")
 
 
 def _orphan_specs(graph: Graph) -> list[str]:

--- a/skills/graph/lib/test_graph.py
+++ b/skills/graph/lib/test_graph.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# Governing: ADR-0023 (Frontmatter DAG and /sdd:graph Skill), SPEC-0018 REQ "Diagnostic Query Verbs"
+"""Unit tests for the graph helper's governing-comment parsing and the
+`orphans` verb's classification of source files.
+
+Run with `make test-graph` or:
+
+    python3 -m unittest discover -s skills/graph/lib -p 'test_*.py'
+
+Stdlib only, like graph.py itself. Each test builds a throwaway project
+tree under a temp dir so the walk is exercised end to end rather than
+through regex fixtures alone.
+
+@joestump 09/03/2026 - Added with the fix for #216: issue-style
+`Governing: #24` lines used to suppress a correct artifact-style line
+below them, JSDoc `* Governing:` was never recognized, and both cases
+were reported as "no governing comment" alongside genuinely comment-less
+files.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import graph
+
+
+def _write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _seed_artifacts(root: Path) -> None:
+    """One ADR and two specs, so code edges have something to resolve to."""
+    _write(
+        root,
+        "docs/adrs/ADR-0009-grid.md",
+        "---\nstatus: accepted\ndate: 2026-01-01\n---\n\n# ADR-0009: Fixed grid\n",
+    )
+    _write(
+        root,
+        "docs/openspec/specs/grid/spec.md",
+        "---\nstatus: approved\ndate: 2026-01-01\nimplements: [ADR-0009]\n---\n\n# SPEC-0006: Grid\n",
+    )
+    _write(
+        root,
+        "docs/openspec/specs/selectors/spec.md",
+        "---\nstatus: approved\ndate: 2026-01-01\n---\n\n# SPEC-0007: Selectors\n",
+    )
+
+
+class GoverningCommentParsingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        _seed_artifacts(self.root)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _build(self) -> graph.Graph:
+        return graph.build_graph(
+            self.root,
+            self.root / "docs" / "adrs",
+            self.root / "docs" / "openspec" / "specs",
+        )
+
+    def test_issue_ref_line_does_not_suppress_artifact_line(self) -> None:
+        # The reproduction from #216: the first `Governing:` names an issue,
+        # a later one names real artifacts. The file must be credited to
+        # the artifacts, not filed as comment-less.
+        _write(
+            self.root,
+            "src/grid.js",
+            "// Governing: #24 (memoized derived-state selectors)\n"
+            "\n"
+            "// ... later ...\n"
+            "// Governing: ADR-0009, SPEC-0006 REQ \"Equipment Occupies a Fixed Eight-Cell Grid\"\n"
+            "export function thing() {}\n",
+        )
+        edges = graph.discover_code_edges(self.root)
+        self.assertEqual([(self.root / "src" / "grid.js", ["ADR-0009", "SPEC-0006"])], edges)
+        self.assertEqual([], graph.discover_orphan_code(self.root))
+        self.assertEqual([], graph.discover_unrecognized_governing(self.root))
+
+    def test_ids_are_unioned_across_governing_and_implements_lines(self) -> None:
+        # The canonical two-line block: IDs come from both lines.
+        _write(
+            self.root,
+            "src/a.py",
+            "# Governing: ADR-0009 (grid)\n"
+            "# Implements: SPEC-0006 REQ \"Grid\"\n"
+            "# Governing: SPEC-0007 REQ \"Selectors\"\n",
+        )
+        edges = graph.discover_code_edges(self.root)
+        self.assertEqual(1, len(edges))
+        self.assertEqual(["ADR-0009", "SPEC-0006", "SPEC-0007"], edges[0][1])
+
+    def test_jsdoc_star_opener_is_recognized(self) -> None:
+        _write(
+            self.root,
+            "src/selectors.js",
+            "/**\n"
+            " * Memoized selectors.\n"
+            " *\n"
+            " * Governing: ADR-0009, SPEC-0007 REQ \"Selectors\"\n"
+            " */\n"
+            "export const x = 1;\n",
+        )
+        edges = graph.discover_code_edges(self.root)
+        self.assertEqual([(self.root / "src" / "selectors.js", ["ADR-0009", "SPEC-0007"])], edges)
+
+    def test_block_comment_opener_with_closer_on_same_line(self) -> None:
+        _write(self.root, "src/one.c", "/* Governing: ADR-0009 (grid) */\nint x;\n")
+        edges = graph.discover_code_edges(self.root)
+        self.assertEqual([(self.root / "src" / "one.c", ["ADR-0009"])], edges)
+
+    def test_marker_with_no_ids_is_unrecognized_not_orphan(self) -> None:
+        _write(self.root, "src/issue_only.js", "// Governing: #24 (some issue)\nexport const y = 2;\n")
+        self.assertEqual([], graph.discover_orphan_code(self.root))
+        unrecognized = graph.discover_unrecognized_governing(self.root)
+        self.assertEqual(
+            [(self.root / "src" / "issue_only.js", graph.UNRECOGNIZED_NO_IDS)], unrecognized
+        )
+
+    def test_marker_in_unknown_opener_is_unrecognized_not_orphan(self) -> None:
+        # SQL/Lua style `--` is not an accepted opener; the operator should
+        # be told the comment exists but cannot be read.
+        _write(self.root, "src/schema.sql", "-- Governing: ADR-0009 (grid)\nSELECT 1;\n")
+        self.assertEqual([], graph.discover_orphan_code(self.root))
+        self.assertEqual([], graph.discover_code_edges(self.root))
+        unrecognized = graph.discover_unrecognized_governing(self.root)
+        self.assertEqual(
+            [(self.root / "src" / "schema.sql", graph.UNRECOGNIZED_OPENER)], unrecognized
+        )
+
+    def test_file_without_marker_is_an_orphan(self) -> None:
+        _write(self.root, "src/plain.js", "export const z = 3;\n")
+        self.assertEqual([self.root / "src" / "plain.js"], graph.discover_orphan_code(self.root))
+        self.assertEqual([], graph.discover_unrecognized_governing(self.root))
+
+    def test_validate_warns_on_unrecognized_governing(self) -> None:
+        _write(self.root, "src/issue_only.js", "// Governing: #24 (some issue)\n")
+        _write(self.root, "src/plain.js", "export const z = 3;\n")
+        g = self._build()
+        self.assertFalse(g.has_errors())
+        codes = [(d.code, d.source_id) for d in g.diagnostics]
+        self.assertIn(("governing-unrecognized", "src/issue_only.js"), codes)
+        # A genuinely comment-less file is an orphan, not a validation warning.
+        self.assertNotIn(("governing-unrecognized", "src/plain.js"), codes)
+
+    def test_validate_json_carries_the_warning(self) -> None:
+        _write(self.root, "src/issue_only.js", "// Governing: #24 (some issue)\n")
+        payload = json.loads(graph._validate_json(self._build()))
+        diags = payload["results"]["diagnostics"]
+        self.assertEqual(1, len(diags))
+        self.assertEqual("warning", diags[0]["severity"])
+        self.assertEqual("governing-unrecognized", diags[0]["code"])
+
+
+class OrphansVerbTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        _seed_artifacts(self.root)
+        _write(self.root, "src/plain.js", "export const z = 3;\n")
+        _write(self.root, "src/issue_only.js", "// Governing: #24 (some issue)\n")
+        _write(
+            self.root,
+            "src/grid.js",
+            "// Governing: #24 (some issue)\n"
+            "// Governing: ADR-0009, SPEC-0006 REQ \"Grid\"\n",
+        )
+        _write(self.root, "lib/other.js", "// Governing: #99\n")
+        self.g = graph.build_graph(
+            self.root,
+            self.root / "docs" / "adrs",
+            self.root / "docs" / "openspec" / "specs",
+        )
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_markdown_splits_unrecognized_from_orphans(self) -> None:
+        out = graph.cmd_orphans(self.g, root=self.root)
+        self.assertIn("## Source files without governing artifacts", out)
+        self.assertIn("## Source files with unrecognized governing comments", out)
+        without, _, unrecognized = out.partition("## Source files with unrecognized governing comments")
+        self.assertIn("`src/plain.js`", without)
+        self.assertNotIn("`src/issue_only.js`", without)
+        self.assertIn("`src/issue_only.js`", unrecognized)
+        self.assertIn(graph.UNRECOGNIZED_NO_IDS, unrecognized)
+        # The file credited via its second governing line appears nowhere.
+        self.assertNotIn("`src/grid.js`", out)
+
+    def test_spec_referenced_only_after_issue_line_is_not_orphaned(self) -> None:
+        out = graph.cmd_orphans(self.g, root=self.root)
+        self.assertNotIn("| SPEC-0006 |", out)
+        # SPEC-0007 has no implementing code at all and stays flagged.
+        self.assertIn("| SPEC-0007 |", out)
+
+    def test_json_has_separate_unrecognized_key(self) -> None:
+        payload = json.loads(graph._orphans_json(self.g, self.root, None))
+        results = payload["results"]
+        self.assertEqual(["src/plain.js"], results["code_files_without_governing"])
+        self.assertEqual(
+            [
+                {"file": "lib/other.js", "reason": graph.UNRECOGNIZED_NO_IDS},
+                {"file": "src/issue_only.js", "reason": graph.UNRECOGNIZED_NO_IDS},
+            ],
+            results["code_files_with_unrecognized_governing"],
+        )
+        self.assertEqual(["SPEC-0007"], results["specs_without_implementing_code"])
+
+    def test_scope_applies_to_unrecognized_too(self) -> None:
+        payload = json.loads(graph._orphans_json(self.g, self.root, "src"))
+        results = payload["results"]
+        self.assertEqual(
+            [{"file": "src/issue_only.js", "reason": graph.UNRECOGNIZED_NO_IDS}],
+            results["code_files_with_unrecognized_governing"],
+        )
+        self.assertEqual(["src/plain.js"], results["code_files_without_governing"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #216.

## What was wrong

`skills/graph/lib/graph.py` `_walk_code_files` used `_GOVERNING_RE.search()` — the **first** `Governing:` line decided the file's fate — and only accepted `//`, `#`, `<!--` as openers. So:

- `// Governing: #24` above a correct `// Governing: ADR-0009, SPEC-0006 …` line → file filed as **comment-less**, and SPEC-0006 falsely listed under "Specs with no implementing code".
- JSDoc `* Governing: …` → never matched.
- `// Implements: SPEC-XXXX …` (the second line of the canonical block) → never read at all.

All three collapsed into the same "Source files without governing artifacts" table as genuinely comment-less files, so the operator could not tell "no traceability" from "traceability the parser cannot read" — and acting on the output meant adding comments to files that already had them.

## What changed

- **Scan every `Governing:` / `Implements:` line** in the 4096-byte head with `finditer` and union the IDs. An issue-style line no longer suppresses an artifact-style one.
- **Accept `*` and `/*` openers** (JSDoc / block-comment continuation), with an optional `*/` closer.
- **New orphan category**: "Source files with unrecognized governing comments" — marker present, no ID readable — rendered as its own table with a `Reason` column, and as `code_files_with_unrecognized_governing: [{file, reason}]` in `--json`. Existing keys are unchanged.
- **New `validate` warning** `governing-unrecognized` for the same files, same class as `authored-derived-edge`. Warnings do not block queries.
- `--scope` applies to the new category too.
- Docs: `skills/graph/SKILL.md` (four categories, how comments are read, JSON shape), SPEC-0018 `orphans` row + two new scenarios, `shared-patterns.md` § "Governing Comment Format" note.
- **Tests**: `skills/graph/lib/test_graph.py` (13 cases, stdlib `unittest`, builds throwaway project trees) and a `make test-graph` target now part of `make test`, so CI runs it. These are the helper's first unit tests.

## Verification

```
$ make test-graph                       # on this branch
Ran 13 tests in 0.022s — OK

$ python3 -m unittest …                 # same tests against origin/main's graph.py
FAILED (failures=11, errors=2)          # only the two pure-orphan cases pass on main

$ make check                            # lint + test (incl. docs build) + gitleaks
make-exit=0
```

Smoke on this repo: `validate` node/edge counts are identical before and after (60 nodes, 130 authored / 127 derived edges); no new warnings, because the plugin's own files all use the canonical format.

## Not in this PR

- `validate --root .` on this repo has a **pre-existing hard error**: `cycle detected (extends): ADR-0024 -> ADR-0025 -> ADR-0024`. Reproduces with `origin/main`'s helper; filed separately.
- The 4096-byte head limit is unchanged — the documented format is file-level at the top of the file.

🤖 Posted on behalf of `@joestump` by [`claude-fable-5-1`](https://openrouter.ai/anthropic/claude-fable-5-1) using [Claude Code](https://claude.com/claude-code).
